### PR TITLE
modernize for crow v3

### DIFF
--- a/lib/_crow.lua
+++ b/lib/_crow.lua
@@ -1,12 +1,13 @@
 local _crow = {}
 
 function _crow.init()
-  crow.init()
-  crow.clear()
-  crow.reset()
   crow.output[2].action = "pulse(.1, 5, 1)"
   crow.output[4].action = "pulse(.1, 5, 1)"
-  crow.ii.pullup(true)
+  crow.ii.jf.mode(1)
+end
+
+norns.crow.add = function()
+  norns.crow.init()
   crow.ii.jf.mode(1)
 end
 
@@ -19,7 +20,7 @@ function _crow:play(note, pair)
   if not fn.is_int(note) then return end
   local output_pairs = {{1,2},{3,4}}
   crow.output[output_pairs[pair][1]].volts = (note - 60) / 12
-  crow.output[output_pairs[pair][2]].execute()
+  crow.output[output_pairs[pair][2]]()
 end
 
 return _crow


### PR DESCRIPTION
ahoy!
just some tiny changes to _crow.init which should correctly startup the system. notably `norns.crow.init()` is called by the script-loader before passing to yggdrasil's `init` function, so crow is already in a blank slate.
the pullup line is removed bc after the above `init` crow will have them enabled.

added is `norns.crow.add` which captures hotplugging the crow, initializes it & enters jf-synth mode.

it's regrettably untested, but i'm slashing & burning tickets...